### PR TITLE
Add standard id parameter to rpc call

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -225,12 +225,14 @@ function generateRPCMethods(constructor, apiCalls, rpc) {
         this.batchedCalls.push({
           jsonrpc: '2.0',
           method: methodName,
-          params: slice(arguments)
+          params: slice(arguments),
+          id: getRandomId()
         });
       } else {
         rpc.call(this, {
           method: methodName,
-          params: slice(arguments, 0, arguments.length - 1)
+          params: slice(arguments, 0, arguments.length - 1),
+          id: getRandomId()
         }, arguments[arguments.length - 1]);
       }
 
@@ -266,6 +268,10 @@ function generateRPCMethods(constructor, apiCalls, rpc) {
     constructor.prototype[methodName] = constructor.prototype[k];
   }
 
+}
+
+function getRandomId() {
+  return parseInt(Math.random() * 100000);
 }
 
 generateRPCMethods(RpcClient, callspec, rpc);


### PR DESCRIPTION
The [JSON RPC spec](http://json-rpc.org/wiki/specification) defines `id` as a required parameter for all requests.

Bitcoind RPC server does not check the parameter, but other implementations may do it.