### PR TITLE
Typo: Identifier for string parameter is "str" not "string"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -254,7 +254,7 @@ function generateRPCMethods(constructor, apiCalls, rpc) {
       if(types[spec[i]]) {
         spec[i] = types[spec[i]];
       } else {
-        spec[i] = types.string;
+        spec[i] = types.str;
       }
     }
     var methodName = k.toLowerCase();


### PR DESCRIPTION
var types = {
    str: function(arg) {
      return arg.toString();
    }, ...

So should use "types.str" not "types.string" as fallback for unknown type identifiers