### PR TITLE
Fix bug where '' spec equals 'string' spec

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -257,12 +257,15 @@ function generateRPCMethods(constructor, apiCalls, rpc) {
   };
 
   for(var k in apiCalls) {
-    var spec = apiCalls[k].split(' ');
-    for (var i = 0; i < spec.length; i++) {
-      if(types[spec[i]]) {
-        spec[i] = types[spec[i]];
-      } else {
-        spec[i] = types.str;
+    var spec = [];
+    if (apiCalls[k].length) {
+      spec = apiCalls[k].split(' ');
+      for (var i = 0; i < spec.length; i++) {
+        if(types[spec[i]]) {
+          spec[i] = types[spec[i]];
+        } else {
+          spec[i] = types.str;
+        }
       }
     }
     var methodName = k.toLowerCase();


### PR DESCRIPTION
Because ''.split(' ') returns [''], all empty API specs ('') were
implicitly converted to a 'str' spec.

This is a bug because for example, createRawTransaction takes an array
of objects as a first argument but bitcoind-rpc serialized the first
argument using `.toString`:

> [ {} ].toString()
> '[object Object]'
