### PR TITLE
bitcoind address index

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -85,8 +85,10 @@ function rpc(request, callback) {
         callback(new Error(errorMessage + 'Connection Rejected: 403 Forbidden'));
         return;
       }
-      if (res.statusCode === 500) {
-        callback(new Error('Bitcoin JSON-RPC: ' + buf.toString('utf8')));
+      if (res.statusCode === 500 && buf.toString('utf8') === 'Work queue depth exceeded') {
+        var exceededError = new Error('Bitcoin JSON-RPC: ' + buf.toString('utf8'));
+        exceededError.code = 429; // Too many requests
+        callback(exceededError);
         return;
       }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -144,6 +144,7 @@ RpcClient.callspec = {
   getAccountAddress: 'str',
   getAddedNodeInfo: '',
   getAddressBalance: 'obj',
+  getAddressDeltas: 'obj',
   getAddressTxids: 'obj',
   getAddressesByAccount: '',
   getBalance: 'str int',

--- a/lib/index.js
+++ b/lib/index.js
@@ -174,6 +174,7 @@ RpcClient.callspec = {
   getRawTransaction: 'str int',
   getReceivedByAccount: 'str int',
   getReceivedByAddress: 'str int',
+  getSpentInfo: 'obj',
   getTransaction: '',
   getTxOut: 'str int bool',
   getTxOutSetInfo: '',

--- a/lib/index.js
+++ b/lib/index.js
@@ -143,6 +143,8 @@ RpcClient.callspec = {
   getAccount: '',
   getAccountAddress: 'str',
   getAddedNodeInfo: '',
+  getAddressMempool: 'obj',
+  getAddressUtxos: 'obj',
   getAddressBalance: 'obj',
   getAddressDeltas: 'obj',
   getAddressTxids: 'obj',

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,9 +105,11 @@ function rpc(request, callback) {
 
   req.on('error', function(e) {
     var err = new Error(errorMessage + 'Request Error: ' + e.message);
-    self.log.err(err);
     if (!called) {
       called = true;
+      if (!callback) {
+        self.log.err(err);
+      }
       callback(err);
     }
   });
@@ -141,12 +143,16 @@ RpcClient.callspec = {
   getAccount: '',
   getAccountAddress: 'str',
   getAddedNodeInfo: '',
+  getAddressBalance: 'obj',
+  getAddressTxids: 'obj',
   getAddressesByAccount: '',
   getBalance: 'str int',
   getBestBlockHash: '',
-  getBlock: '',
+  getBlock: 'str bool',
+  getBlockchainInfo: '',
   getBlockCount: '',
   getBlockHash: 'int',
+  getBlockHeader: 'str',
   getBlockNumber: '',
   getBlockTemplate: '',
   getConnectionCount: '',

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ function rpc(request, callback) {
 
   var called = false;
 
-  var errorMessage = 'Bitcoin Core JSON-RPC: host=' + self.host + ' port=' + self.port + ': ';
+  var errorMessage = 'Bitcoin JSON-RPC: ';
 
   var req = this.protocol.request(options, function(res) {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -107,9 +107,6 @@ function rpc(request, callback) {
     var err = new Error(errorMessage + 'Request Error: ' + e.message);
     if (!called) {
       called = true;
-      if (!callback) {
-        self.log.err(err);
-      }
       callback(err);
     }
   });

--- a/lib/index.js
+++ b/lib/index.js
@@ -151,6 +151,7 @@ RpcClient.callspec = {
   getBlock: 'str bool',
   getBlockchainInfo: '',
   getBlockCount: '',
+  getBlockHashes: 'int int',
   getBlockHash: 'int',
   getBlockHeader: 'str',
   getBlockNumber: '',

--- a/lib/index.js
+++ b/lib/index.js
@@ -85,6 +85,10 @@ function rpc(request, callback) {
         callback(new Error(errorMessage + 'Connection Rejected: 403 Forbidden'));
         return;
       }
+      if (res.statusCode === 500) {
+        callback(new Error('Bitcoin JSON-RPC: ' + buf.toString('utf8')));
+        return;
+      }
 
       var parsedBuf;
       try {

--- a/test/index.js
+++ b/test/index.js
@@ -261,7 +261,7 @@ describe('RpcClient', function() {
     client.getBalance('n28S35tqEMbt6vNad7A5K3mZ7vdn8dZ86X', 6, function(error, parsedBuf) {
       requestStub.restore();
       should.exist(error);
-      error.message.should.equal('Bitcoin Core JSON-RPC: host=localhost port=8332: Connection Rejected: 401 Unnauthorized');
+      error.message.should.equal('Bitcoin JSON-RPC: Connection Rejected: 401 Unnauthorized');
       done();
     });
 
@@ -291,7 +291,7 @@ describe('RpcClient', function() {
     client.getDifficulty(function(error, parsedBuf) {
       requestStub.restore();
       should.exist(error);
-      error.message.should.equal('Bitcoin Core JSON-RPC: host=localhost port=8332: Connection Rejected: 403 Forbidden');
+      error.message.should.equal('Bitcoin JSON-RPC: Connection Rejected: 403 Forbidden');
       done();
     });
 
@@ -356,7 +356,7 @@ describe('RpcClient', function() {
     client.getDifficulty(function(error, parsedBuf) {
       requestStub.restore();
       should.exist(error);
-      error.message.should.equal('Bitcoin Core JSON-RPC: host=localhost port=8332: Request Error: write EPIPE');
+      error.message.should.equal('Bitcoin JSON-RPC: Request Error: write EPIPE');
       done();
     });
 
@@ -419,7 +419,7 @@ describe('RpcClient', function() {
     client.getDifficulty(function(error, parsedBuf) {
       requestStub.restore();
       should.exist(error);
-      error.message.should.equal('Bitcoin Core JSON-RPC: host=localhost port=8332: Request Error: connect ECONNREFUSED');
+      error.message.should.equal('Bitcoin JSON-RPC: Request Error: connect ECONNREFUSED');
       done();
     });
 
@@ -450,7 +450,7 @@ describe('RpcClient', function() {
     client.getDifficulty(function(error, parsedBuf) {
       requestStub.restore();
       should.exist(error);
-      error.message.should.equal('Bitcoin Core JSON-RPC: host=localhost port=8332: Error Parsing JSON: Unexpected token o');
+      error.message.should.equal('Bitcoin JSON-RPC: Error Parsing JSON: Unexpected token o');
       done();
     });
 
@@ -481,7 +481,7 @@ describe('RpcClient', function() {
     client.getDifficulty(function(error, parsedBuf) {
       requestStub.restore();
       should.exist(error);
-      error.message.should.equal('Bitcoin Core JSON-RPC: host=localhost port=8332: Error Parsing JSON: Unexpected end of input');
+      error.message.should.equal('Bitcoin JSON-RPC: Error Parsing JSON: Unexpected end of input');
       done();
     });
 


### PR DESCRIPTION
Adds spec for methods implemented in https://github.com/bitpay/bitcoin/pull/6:
- `getAddressMempool`
- `getAddressUtxos`
- `getAddressBalance`,
- `getAddressDeltas`
- `getAddressTxids`
- `getBlockHashes` 
- `getSpentInfo`

Fixes spec for:
- `getBlock`

Adds new specs:
- `getBlockchainInfo`
- `getBlockHeader`