### PR TITLE
Added parameters for createRawTransaction

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -137,7 +137,7 @@ RpcClient.callspec = {
   addNode: '',
   backupWallet: '',
   createMultiSig: '',
-  createRawTransaction: '',
+  createRawTransaction: 'obj obj',
   decodeRawTransaction: '',
   dumpPrivKey: '',
   encryptWallet: '',


### PR DESCRIPTION
I've added these parameters to createRawTransaction so you can call the function sending it an array of txid/vout maps, and a map of address keys with their corresponding amount values, as I was unable to get it to function correctly without these changes.