### PR TITLE
Adding queue to prevent 'Bitcoin JSON-RPC: Work queue depth exceeded' errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 var http = require('http');
 var https = require('https');
+var async = require('async');
 
 function RpcClient(opts) {
   opts = opts || {};
@@ -12,6 +13,7 @@ function RpcClient(opts) {
   this.protocol = opts.protocol === 'http' ? http : https;
   this.batchedCalls = null;
   this.disableAgent  = opts.disableAgent || false;
+  var queueSize = opts.queue || 16;
 
   var isRejectUnauthorized = typeof opts.rejectUnauthorized !== 'undefined';
   this.rejectUnauthorized = isRejectUnauthorized ? opts.rejectUnauthorized : true;
@@ -22,6 +24,9 @@ function RpcClient(opts) {
     this.log = RpcClient.loggers[RpcClient.config.logger || 'normal'];
   }
 
+  this.queue = async.queue(function(task, callback) {
+    task(callback);
+  }, queueSize);
 }
 
 var cl = console.log.bind(console);
@@ -39,6 +44,21 @@ RpcClient.config = {
 };
 
 function rpc(request, callback) {
+
+  var self = this;
+
+  var task = function(taskCallback) {
+    var newCallback = function() {
+      callback.apply(undefined, arguments);
+      taskCallback();
+    };
+    innerRpc.call(self, request, newCallback);
+  };
+
+  this.queue.push(task);
+}
+
+function innerRpc(request, callback) {
 
   var self = this;
   request = JSON.stringify(request);

--- a/package.json
+++ b/package.json
@@ -39,12 +39,14 @@
     "coverage": "node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- --recursive"
   },
   "devDependencies": {
-    "async": "^0.9.0",
     "chai": "^1.10.0",
     "coveralls": "^2.11.2",
     "istanbul": "^0.3.5",
     "mocha": "^2.1.0",
     "sinon": "^1.12.2"
+  },
+  "dependencies": {
+    "async": "^1.3.0"
   },
   "bugs": {
     "url": "https://github.com/bitpay/bitcoind-rpc/issues"


### PR DESCRIPTION
I have added a queue, fixing recurring "Bitcoin JSON-RPC: Work queue depth exceeded" errors.

The queue size can be set from calling code by options (I will add it to bitcore-node next); by default, 16 is used, since that's the default bitcoind queue size.

Fixes issues:
* https://github.com/bitpay/bitcore-node/issues/463
* https://github.com/bitpay/insight-api/issues/492
* https://github.com/bitpay/insight-ui/issues/749

and maybe others

I am using the same async version as bitcore-node, so it's not installed twice with different versions :)