### PR TITLE
Allow access to getrawmempool verbose mode

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -175,7 +175,7 @@ RpcClient.callspec = {
   getMiningInfo: '',
   getNewAddress: '',
   getPeerInfo: '',
-  getRawMemPool: '',
+  getRawMemPool: 'bool',
   getRawTransaction: 'str int',
   getReceivedByAccount: 'str int',
   getReceivedByAddress: 'str int',


### PR DESCRIPTION
This will give access to the ancestorsize and ancestorfees for txes in the mempool.

I am using this to implement CPFP needed fees api for insight-api