### PR TITLE
Make options compatible with url.parse() format

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,11 +5,11 @@ var https = require('https');
 
 function RpcClient(opts) {
   opts = opts || {};
-  this.host = opts.host || '127.0.0.1';
+  this.host = opts.hostname || opts.host || '127.0.0.1';
   this.port = opts.port || 8332;
-  this.user = opts.user || 'user';
-  this.pass = opts.pass || 'pass';
-  this.protocol = opts.protocol === 'http' ? http : https;
+  this.user = opts.username || opts.user || 'user';
+  this.pass = opts.password || opts.pass || 'pass';
+  this.protocol = opts.protocol === 'http' || opts.protocol === 'http:' ? http : https;
   this.batchedCalls = null;
   this.disableAgent  = opts.disableAgent || false;
 


### PR DESCRIPTION
So that `new RpcClient(require('url').parse('https://bob:1234@127.0.0.1:18332'))` works.

Retains backwards compatibility with the previous options format.