### PR TITLE
Adds support for "generatetoaddress"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -144,7 +144,7 @@ RpcClient.callspec = {
   estimateFee: 'int',
   estimatePriority: 'int',
   generate: 'int',
-  generatetoaddress: 'int str',
+  generateToAddress: 'int str',
   getAccount: '',
   getAccountAddress: 'str',
   getAddedNodeInfo: '',

--- a/lib/index.js
+++ b/lib/index.js
@@ -144,6 +144,7 @@ RpcClient.callspec = {
   estimateFee: 'int',
   estimatePriority: 'int',
   generate: 'int',
+  generatetoaddress: 'int str',
   getAccount: '',
   getAccountAddress: 'str',
   getAddedNodeInfo: '',


### PR DESCRIPTION
This is a simple change that adds support for the `generatetoaddress` RPC function [added to core in 0.13.0.](https://bitcoin.org/en/release/v0.13.0)