### PR TITLE
Adds estimatesmartfee

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -144,6 +144,7 @@ RpcClient.callspec = {
   estimateFee: 'int',
   estimateSmartFee: 'int str',
   estimatePriority: 'int',
+  estimateSmartFee: 'int str',
   generate: 'int',
   generateToAddress: 'int str',
   getAccount: '',


### PR DESCRIPTION
Adds support for `estimatesmartfee`

Ala. https://bitcoincore.org/en/doc/0.16.0/rpc/util/estimatesmartfee/