### PR TITLE
Update getBlock verbosity to int

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -184,7 +184,7 @@ RpcClient.callspec = {
   getBalance: 'str int',
   getBestBlockHash: '',
   getBlockDeltas: 'str',
-  getBlock: 'str bool',
+  getBlock: 'str int',
   getBlockchainInfo: '',
   getBlockCount: '',
   getBlockHashes: 'int int obj',


### PR DESCRIPTION
The `getBlock` RPC call takes an integer argument after the block hash to specify verbosity. This PR updates the call to expose this functionality.

https://bitcoincore.org/en/doc/0.17.0/rpc/blockchain/getblock/