### PR TITLE
Do not use the deprecated Buffer() constructor

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,6 +39,12 @@ function RpcClient(opts) {
   this.batchedCalls = null;
   this.disableAgent  = opts.disableAgent || false;
 
+  var userInfo = this.user + ':' + this.pass;
+  var buf = Buffer.from && Buffer.from !== Uint8Array.from
+    ? Buffer.from(userInfo)
+    : new Buffer(userInfo);
+  this.auth = buf.toString('base64');
+
   var isRejectUnauthorized = typeof opts.rejectUnauthorized !== 'undefined';
   this.rejectUnauthorized = isRejectUnauthorized ? opts.rejectUnauthorized : true;
 
@@ -68,7 +74,6 @@ function rpc(request, callback) {
 
   var self = this;
   request = JSON.stringify(request);
-  var auth = new Buffer(self.user + ':' + self.pass).toString('base64');
 
   var options = {
     host: self.host,
@@ -145,7 +150,7 @@ function rpc(request, callback) {
 
   req.setHeader('Content-Length', request.length);
   req.setHeader('Content-Type', 'application/json');
-  req.setHeader('Authorization', 'Basic ' + auth);
+  req.setHeader('Authorization', 'Basic ' + self.auth);
   req.write(request);
   req.end();
 }


### PR DESCRIPTION
This fixes the [`Buffer()` constructor deprecation warning](https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor).