### PR TITLE
Fix use of xvfb on Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
-- '0.10'
-before_install:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+  - '0.10'
+services:
+  - xvfb
 install:
   - npm install
 after_script:


### PR DESCRIPTION
Travis made breaking changes to using Xvfb back in January ([source](https://changelog.travis-ci.com/ubuntu-xenial-16-04-build-environment-update-86123)), this fixes the Travis builds using the updated instructions ([source](https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-services)).