### PR TITLE
added `pathname`  for non-default wallet

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,7 @@ function decodeURL(str) {
   var hostname = parsedUrl.hostname;
   var port = parseInt(parsedUrl.port, 10);
   var protocol = parsedUrl.protocol;
+  var pathname = parsedUrl.pathname;
   // strip trailing ":"
   protocol = protocol.substring(0, protocol.length - 1);
   var auth = parsedUrl.auth;
@@ -19,6 +20,7 @@ function decodeURL(str) {
     host: hostname,
     port: port,
     protocol: protocol,
+    pathname: pathname,
     user: user,
     pass: pass,
   };
@@ -36,6 +38,7 @@ function RpcClient(opts) {
   this.user = opts.user || 'user';
   this.pass = opts.pass || 'pass';
   this.protocol = opts.protocol === 'http' ? http : https;
+  this.pathname = opts.pathname;
   this.batchedCalls = null;
   this.disableAgent  = opts.disableAgent || false;
 
@@ -72,7 +75,7 @@ function rpc(request, callback) {
 
   var options = {
     host: self.host,
-    path: '/',
+    path: self.pathname,
     method: 'POST',
     port: self.port,
     rejectUnauthorized: self.rejectUnauthorized,


### PR DESCRIPTION
```bash
bitcoin-cli -?
-rpcwallet=<walletname>
      Send RPC for non-default wallet on RPC server (needs to exactly match
      corresponding -wallet option passed to bitcoind). This changes
      the RPC endpoint used, e.g.
      http://127.0.0.1:8332/wallet/<walletname>
```