### PR TITLE
Move auth back to rpc

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,12 +39,6 @@ function RpcClient(opts) {
   this.batchedCalls = null;
   this.disableAgent  = opts.disableAgent || false;
 
-  var userInfo = this.user + ':' + this.pass;
-  var buf = Buffer.from && Buffer.from !== Uint8Array.from
-    ? Buffer.from(userInfo)
-    : new Buffer(userInfo);
-  this.auth = buf.toString('base64');
-
   var isRejectUnauthorized = typeof opts.rejectUnauthorized !== 'undefined';
   this.rejectUnauthorized = isRejectUnauthorized ? opts.rejectUnauthorized : true;
 
@@ -74,6 +68,10 @@ function rpc(request, callback) {
 
   var self = this;
   request = JSON.stringify(request);
+
+  var userInfo = this.user + ':' + this.pass;
+  var buf = (Buffer.from && Buffer.from !== Uint8Array.from) ? Buffer.from(userInfo) : new Buffer(userInfo);
+  this.auth = buf.toString('base64');
 
   var options = {
     host: self.host,


### PR DESCRIPTION
The move from the `rpc` function to constructor breaks current implementations. This PR moves it back to `rpc`